### PR TITLE
Fixed Some Dead Lock Bug

### DIFF
--- a/bucket.py
+++ b/bucket.py
@@ -54,10 +54,17 @@ class Bucket:
         lista = msg.split()
         print(lista)
         command = lista[0].upper()
+        if len(lista) > 1 and command in ("INSERT", "QUERY"):
+            key = int(lista[1])
+            location = address(key, Bucket.fs)
+            if location != Bucket.bucketNbr:
+                return Bucket.forward(location, msg) 
         try:
             if command == "INSERT":
-                Bucket.insert(int(lista[1]), lista[2])
-                return "ACK"
+                response = Bucket.insert(int(lista[1]), lista[2])
+                if len(lista) > 3 and lista[3] == "FWD":
+                    response = "IAM {}".format(Bucket.fs.extent)
+                return response
             elif command == "QUERY":
                 return Bucket.query(int(lista[1]))
             elif command == "POPULATION":
@@ -74,6 +81,7 @@ class Bucket:
 
     def insert(key, val):
         Bucket.dicc[key] = val
+        result = "ACK"
         if len(Bucket.dicc) > 2 and Bucket.bucketNbr > 0:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
@@ -81,11 +89,13 @@ class Bucket:
                 sock.connect((Bucket.coHost, Bucket.coPort))
                 data = "SPLIT"
                 sock.sendall(bytes(data + "\n", "utf-8"))
-                # Receive data from the server
-                received = str(sock.recv(1024), "utf-8")
+#                 # Receive data from the server
+#                 result = str(sock.recv(1024), "utf-8")
+#                 The above line might cause a dead lock
             finally:
                 #Close connection
                 sock.close()
+        return result
 
     def query(key):
         return Bucket.dicc[key]
@@ -99,7 +109,6 @@ class Bucket:
         print(Bucket.bucketList)
 
     def rehash(fs):
-        # rehash each key
         print("Rehashing")
         print(fs)
         deleteList = []
@@ -126,6 +135,7 @@ class Bucket:
                     Bucket.population(reply)
             destAddress = Bucket.bucketList[location].split()
             destHost, destPort = destAddress[0], int(destAddress[1])
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
                 sock.connect((destHost, destPort))
                 data = "INSERT {} {}".format(key, Bucket.dicc[key])
@@ -140,7 +150,44 @@ class Bucket:
         for key in deleteList:
             Bucket.dicc.pop(key)
 
-             
+    def forward(location, msg):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if location not in Bucket.bucketList:
+            try:
+                sock.connect((Bucket.coHost, Bucket.coPort))
+                data = "POPULATE"
+                sock.sendall(bytes(data + "\n", "utf-8"))
+                received = str(sock.recv(1024), "utf-8")
+            finally:
+                #Close connection
+                sock.close()
+            #process reply
+            reply = received.split()
+            Bucket.replyHandler(reply)
+        destAddress = Bucket.bucketList[location].split()
+        destHost, destPort = destAddress[0], int(destAddress[1])
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        received = ""
+        try:
+            sock.connect((destHost, destPort))
+            data = msg + " FWD"
+            sock.sendall(bytes(data + "\n", "utf-8"))
+            received = str(sock.recv(1024), "utf-8")
+        finally:
+            #Close connection
+            sock.close()
+        print(received)
+        return received
+
+def replyHandler(reply):
+    if not reply:
+        return
+    if reply[0] == "POPULATION":
+        Bucket.population(reply)
+    elif reply[0] == "IAM":
+        Bucket.fs = FileState(int(reply[1])) 
+
+
 
 if __name__ == '__main__':            
     bucket = Bucket(MyTCPHandler)

--- a/client.py
+++ b/client.py
@@ -1,35 +1,84 @@
 import socket
 import sys
 from address import address
+from file_state import FileState
 
 
-HOST = "localhost"
-port = int(sys.argv[1])
+coHost = "localhost"
+coPort = int(sys.argv[1])
 
 bucketAddress = {}
-bucketAddress[0] = "{} {}".format(HOST, port)
+bucketAddress[0] = "{} {}".format(coHost, coPort)
 
-while True:
-    data = input("command: ")
-    if data.split()[0].upper() == "STOP":
-        break       
+fs = FileState()
+
+def main():
+    global bucketAddress
+    global fs
+    while True:
+        data = input("command: ")
+        if data.split()[0].upper() == "STOP":
+            break       
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        destAddress = bucketAddress[0].split()
+        destHost, destPort = destAddress[0], int(destAddress[1])
+        if len(data.split()) > 1:
+            key = int(data.split()[1])
+            destBucket = address(key, fs)
+            if destBucket not in bucketAddress:
+                requestPopulate()
+            destAddress = bucketAddress[destBucket].split()
+            destHost, destPort = destAddress[0], int(destAddress[1])
+            print(destHost, destPort)
+        try:
+            # Connect to server and send data
+            sock.connect((destHost, destPort))
+            sock.sendall(bytes(data + "\n", "utf-8"))
+            print("Sent:     {}".format(data))
+            # Receive data from the server
+            received = str(sock.recv(1024), "utf-8")
+        finally:
+            #Close connection
+            sock.close()
+        #process reply
+        reply = received.split()
+        replyHandler(reply)
+        print("Received: {}".format(received))
+
+
+def requestPopulate():
+    global bucketAddress
+    data = "POPULATE"
+    destAddress = bucketAddress[0].split()
+    destHost, destPort = destAddress[0], int(destAddress[1])
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-    # Connect to server and send data
-        sock.connect((HOST, port))
+        sock.connect((destHost, destPort))
         sock.sendall(bytes(data + "\n", "utf-8"))
-    # Receive data from the server
+        print("Sent:     {}".format(data))
+        # Receive data from the server
         received = str(sock.recv(1024), "utf-8")
     finally:
         #Close connection
         sock.close()
     #process reply
     reply = received.split()
+    replyHandler(reply)
+    print("Received: {}".format(received))
+    
+def replyHandler(reply):
+    global bucketAddress
+    global fs
+    if not reply:
+        return
     if reply[0] == "POPULATION":
         i = 1
         while i < len(reply):
             bucketAddress[int(reply[i])] = " ".join([reply[i+1], reply[i+2]])
             i+=3
-    print("Sent:     {}".format(data))
-    print("Received: {}".format(received))
-#     print(bucketAddress)
+    elif reply[0] == "IAM":
+        fs = FileState(int(reply[1]))
+    
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When the coordinator sends out rehash request, it will no longer wait for the target bucket to response. Otherwise, the target bucket may send a populate request to the coordinator while the coordinator is waiting for the rehashing response.
Another case is when the coordinator forwards an insert message and the target bucket exceeds its capacity limit, the target bucket will not wait for the coordinator to response after sending the split request. Otherwise, the coordinator is waiting for the insert response from the target bucket and the target bucket is waiting for the split response from the coordinator.
